### PR TITLE
fix worker import from pdfjs-dist

### DIFF
--- a/client/src/features/cv-management/lib/parse-resume-from-pdf/read-pdf.ts
+++ b/client/src/features/cv-management/lib/parse-resume-from-pdf/read-pdf.ts
@@ -1,8 +1,7 @@
 // Getting pdfjs to work is tricky. The following 3 lines would make it work
 // https://stackoverflow.com/a/63486898/7699841
 import * as pdfjs from 'pdfjs-dist';
-// @ts-expect-error ...
-import pdfjsWorker from 'pdfjs-dist/build/pdf.worker.entry';
+import pdfjsWorker from 'pdfjs-dist/build/pdf.worker?url';
 
 pdfjs.GlobalWorkerOptions.workerSrc = pdfjsWorker;
 

--- a/client/src/features/cv-management/lib/redux/resumeSlice.ts
+++ b/client/src/features/cv-management/lib/redux/resumeSlice.ts
@@ -217,7 +217,7 @@ export const resumeSlice = createSlice({
         draft[form].splice(idx, 1);
       }
     },
-    setResume: (draft, action: PayloadAction<Resume>) => {
+    setResume: (_draft, action: PayloadAction<Resume>) => {
       return action.payload;
     },
   },

--- a/client/src/features/cv-management/lib/redux/settingsSlice.ts
+++ b/client/src/features/cv-management/lib/redux/settingsSlice.ts
@@ -130,7 +130,7 @@ export const settingsSlice = createSlice({
 
       draft['showBulletPoints'][field] = value;
     },
-    setSettings: (draft, action: PayloadAction<Settings>) => {
+    setSettings: (_draft, action: PayloadAction<Settings>) => {
       return action.payload;
     },
   },


### PR DESCRIPTION
## What

Related PR: https://github.com/HarryNguyen2662/CV_management_system/pull/7
It turns out that there is a simple fix for this issue using explicit URL imports in vite documentation. Link here: https://vitejs.dev/guide/assets.html#explicit-url-imports
