### PR TITLE
fix

### DIFF
--- a/client/src/features/cv-management/components/resumes-list-board.tsx
+++ b/client/src/features/cv-management/components/resumes-list-board.tsx
@@ -9,9 +9,10 @@ import {
   PaginationNext,
   PaginationPrevious,
 } from '@/components/ui/pagination';
-import { useGetResumesQuery } from '@/services/apiSlice';
+import { useGetResumesbyPagesQuery, useGetResumesQuery } from '@/services/apiSlice';
 
 import { ResumePreviewCard } from './resume-preview-card';
+import { Resume } from '@/interface/resume';
 
 interface PaginationSelectionProps {
   total: number;
@@ -94,12 +95,17 @@ const PaginationSelection = ({ total, itemsPerPage, currentPage, setCurrentPage 
 };
 
 export const ResumesListBoard = () => {
-  const { data: resumes, isError, error, isLoading, isSuccess } = useGetResumesQuery();
-
   const [currentPage, setCurrentPage] = useState(1);
   const [itemsPerPage] = useState(9);
+  const { data, isError, error, isLoading, isSuccess } = useGetResumesbyPagesQuery({
+    page: currentPage,
+    limit: itemsPerPage,
+  });
+
+  console.log(data);
 
   let content;
+  const resumes = data?.resume || [];
 
   if (isLoading) {
     content = <p>Loading...</p>;
@@ -107,7 +113,7 @@ export const ResumesListBoard = () => {
     const endIndex = currentPage * itemsPerPage;
     const startIndex = endIndex - itemsPerPage;
 
-    content = resumes.slice(startIndex, endIndex).map(resume => <ResumePreviewCard key={resume.id} resume={resume} />);
+    content = resumes.map((resume: Resume) => <ResumePreviewCard key={resume.id} resume={resume} />);
   } else if (isError) {
     content = <div>{error.toString()}</div>;
   }
@@ -118,7 +124,7 @@ export const ResumesListBoard = () => {
         {content}
       </div>
       <PaginationSelection
-        total={resumes ? resumes.length : 0}
+        total={data?.totalCount}
         itemsPerPage={itemsPerPage}
         currentPage={currentPage}
         setCurrentPage={setCurrentPage}

--- a/client/src/interface/resume.ts
+++ b/client/src/interface/resume.ts
@@ -43,6 +43,7 @@ export interface ResumeCustom {
 }
 
 export interface Resume {
+  [x: string]: any;
   profile: ResumeProfile;
   workExperiences: ResumeWorkExperience[];
   educations: ResumeEducation[];
@@ -50,9 +51,9 @@ export interface Resume {
   skills: ResumeSkills;
   custom: ResumeCustom;
   resumePdf: {
-    fileUrl: string,
-    cloudinaryId: string,
-  },
+    fileUrl: string;
+    cloudinaryId: string;
+  };
   id: string;
 }
 

--- a/client/src/services/apiSlice.ts
+++ b/client/src/services/apiSlice.ts
@@ -7,6 +7,27 @@ export const apiSlice = createApi({
   baseQuery: fetchBaseQuery({ baseUrl: 'http://localhost:3000/v1' }),
   tagTypes: ['Resume'],
   endpoints: builder => ({
+    getResumesbyPages: builder.query<Resume[], { limit: number; page: number }>({
+      query: ({ limit, page }) => {
+        const searchParams = new URLSearchParams();
+
+        searchParams.set('limit', limit.toString());
+        searchParams.set('page', page.toString());
+
+        return {
+          url: `/resume/resumepage?${searchParams.toString()}`,
+          method: 'GET',
+        };
+      },
+      providesTags: result => [
+        'Resume',
+        ...result.resume.map(({ id }: { id: string }) => ({
+          type: 'Resume' as const,
+          id,
+        })),
+      ],
+    }),
+
     getResumes: builder.query<Resume[], void>({
       query: () => '/resume',
       providesTags: (result = []) => [
@@ -48,5 +69,10 @@ export const apiSlice = createApi({
   }),
 });
 
-export const { useGetResumesQuery, useUploadNewResumeMutation, useGetResumeByIdQuery, useDeleteResumeByIdMutation } =
-  apiSlice;
+export const {
+  useGetResumesQuery,
+  useUploadNewResumeMutation,
+  useGetResumeByIdQuery,
+  useDeleteResumeByIdMutation,
+  useGetResumesbyPagesQuery,
+} = apiSlice;

--- a/server/src/controllers/resume.controller.js
+++ b/server/src/controllers/resume.controller.js
@@ -1,6 +1,7 @@
 const httpStatus = require('http-status');
 const catchAsync = require('../utils/catchAsync');
 const ApiError = require('../utils/ApiError');
+const pick = require('../utils/pick');
 const { resumeService } = require('../services');
 
 const createResume = catchAsync(async (req, res) => {
@@ -46,8 +47,8 @@ const deleteResume = catchAsync(async (req, res) => {
 
 const getResumeByPage = catchAsync(async (req, res) => {
   const options = pick(req.query, ['sortBy', 'limit', 'page']);
-  const result = await resumeService.getResumeListbyPage(options);
-  res.send(result);
+  const resume = await resumeService.getResumeListbyPage(options);
+  res.send(resume);
 });
 
 module.exports = {


### PR DESCRIPTION
# Implement Pagination for Resume List

## Overview

This pull request introduces pagination functionality to the resume listing feature. It allows users to navigate through pages of resumes.

## Changes

### Frontend


- **ResumesListBoard Component**: This component now uses the `useGetResumesbyPagesQuery` hook from the `apiSlice` to fetch resumes based on the current page and items per page. It handles loading, success, and error states, displaying the appropriate UI for each.
- **API Slice**: The `getResumesbyPages` query has been modified to correctly handle pagination parameters and to tag fetched resumes for efficient cache management.

### Backend (Assumed)

- The backend API endpoint `/resume/resumepage` has been adjusted to accept `limit` and `page` query parameters to return the corresponding slice of resumes. It also returns the total count of resumes to support pagination on the frontend.
